### PR TITLE
Attach VPC and XRay Roles when needed

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,9 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
+  "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
     "ignorePaths": ["**/context.tf", "examples/**"]
   }
 }
-

--- a/README.md
+++ b/README.md
@@ -401,12 +401,14 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Matt Calhoun][mcalhoun_avatar]][mcalhoun_homepage]<br/>[Matt Calhoun][mcalhoun_homepage] |
-|---|
+|  [![Matt Calhoun][mcalhoun_avatar]][mcalhoun_homepage]<br/>[Matt Calhoun][mcalhoun_homepage] | [![PePe Amengual][jamengual_avatar]][jamengual_homepage]<br/>[PePe Amengual][jamengual_homepage] |
+|---|---|
 <!-- markdownlint-restore -->
 
   [mcalhoun_homepage]: https://github.com/mcalhoun
   [mcalhoun_avatar]: https://img.cloudposse.com/150x150/https://github.com/mcalhoun.png
+  [jamengual_homepage]: https://github.com/jamengual
+  [jamengual_avatar]: https://img.cloudposse.com/150x150/https://github.com/jamengual.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.yaml
+++ b/README.yaml
@@ -87,3 +87,5 @@ include:
 contributors:
   - name: "Matt Calhoun"
     github: "mcalhoun"
+  - name: "PePe Amengual"
+    github: "jamengual"

--- a/iam-role.tf
+++ b/iam-role.tf
@@ -32,14 +32,14 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_insights" {
 }
 
 resource "aws_iam_role_policy_attachment" "vpc_access" {
-  count = local.enabled && var.vpc_config != null ? 1 : 0
+  count = local.enabled && try(length(var.vpc_config), 0) > 0 ? 1 : 0
 
   policy_arn = "arn:${local.partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.this[0].name
 }
 
 resource "aws_iam_role_policy_attachment" "xray" {
-  count = local.enabled && var.tracing_config_mode != null ? 1 : 0
+  count = local.enabled && try(length(var.tracing_config_mode), 0) > 0 ? 1 : 0
 
   policy_arn = "arn:${local.partition}:iam::aws:policy/AWSXRayDaemonWriteAccess"
   role       = aws_iam_role.this[0].name

--- a/iam-role.tf
+++ b/iam-role.tf
@@ -32,14 +32,14 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_insights" {
 }
 
 resource "aws_iam_role_policy_attachment" "vpc_access" {
-  count = local.enabled && var.vpc_config == null ? 1 : 0
+  count = local.enabled && var.vpc_config != null ? 1 : 0
 
   policy_arn = "arn:${local.partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
   role       = aws_iam_role.this[0].name
 }
 
 resource "aws_iam_role_policy_attachment" "xray" {
-  count = local.enabled && var.tracing_config_mode == null ? 1 : 0
+  count = local.enabled && var.tracing_config_mode != null ? 1 : 0
 
   policy_arn = "arn:${local.partition}:iam::aws:policy/AWSXRayDaemonWriteAccess"
   role       = aws_iam_role.this[0].name


### PR DESCRIPTION
## what
* Fix iam policy attachment logic

## why
* when Xray to vpc_config is enabled the policy logic does not attach the proper managed policies.

## references
* closes https://github.com/cloudposse/terraform-aws-lambda-function/issues/13
* closes https://github.com/cloudposse/terraform-aws-lambda-function/issues/10
