### PR TITLE
Always add lambda.amazonaws.com id

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,9 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
+  "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
     "ignorePaths": ["**/context.tf", "examples/**"]
   }
 }
-

--- a/iam-role.tf
+++ b/iam-role.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
 
     principals {
       type        = "Service"
-      identifiers = var.lambda_at_edge ? ["edgelambda.amazonaws.com"] : ["lambda.amazonaws.com"]
+      identifiers = concat(["lambda.amazonaws.com"], var.lambda_at_edge ? ["edgelambda.amazonaws.com"] : [])
     }
   }
 }


### PR DESCRIPTION
## what
* Always add lambda.amazonaws.com id

## why
* lambda@edge requires both edgelambda and lambda identifiers

## references
* Closes https://github.com/cloudposse/terraform-aws-lambda-function/issues/14

