### PR TITLE
Return latest version number of aws_lambda_function

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Available targets:
 | <a name="output_qualified_arn"></a> [qualified\_arn](#output\_qualified\_arn) | ARN identifying your Lambda Function Version (if versioning is enabled via publish = true) |
 | <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | Lambda IAM role ARN |
 | <a name="output_role_name"></a> [role\_name](#output\_role\_name) | Lambda IAM role name |
+| <a name="output_version"></a> [version](#output\_version) | Latest published version of your Lambda Function (if versioning is enabled via publish = true) |
 <!-- markdownlint-restore -->
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -106,4 +106,5 @@
 | <a name="output_qualified_arn"></a> [qualified\_arn](#output\_qualified\_arn) | ARN identifying your Lambda Function Version (if versioning is enabled via publish = true) |
 | <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | Lambda IAM role ARN |
 | <a name="output_role_name"></a> [role\_name](#output\_role\_name) | Lambda IAM role name |
+| <a name="output_version"></a> [version](#output\_version) | Latest published version of your Lambda Function (if versioning is enabled via publish = true) |
 <!-- markdownlint-restore -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,11 @@ output "qualified_arn" {
   value       = local.enabled ? aws_lambda_function.this[0].qualified_arn : null
 }
 
+output "version" {
+  description = "Latest published version of your Lambda Function (if versioning is enabled via publish = true)"
+  value       = local.enabled ? aws_lambda_function.this[0].version : null
+}
+
 output "function_name" {
   description = "Lambda function name"
   value       = local.enabled ? aws_lambda_function.this[0].function_name : null


### PR DESCRIPTION
## what
To associate a lambda function to CloudFront distribution as a Lambda@Edge (using a cache behiavor's lambda_function_association block), it is required to provide a numbered version. The `qualified_arn`, unfortunately, always returns `$LATEST` which is not supported by Lambda@Edge.

## why
There appears to be no easy way to query `aws_lambda_function.version` either.

See:
https://github.com/hashicorp/terraform-provider-aws/issues/10038
https://github.com/hashicorp/terraform-provider-aws/issues/25448