### PR TITLE
ignore last_modified attribute

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,10 @@ resource "aws_lambda_function" "this" {
       subnet_ids         = vpc_config.value.subnet_ids
     }
   }
+
+  lifecycle {
+    ignore_changes = [last_modified]
+  }
 }
 
 data "aws_partition" "this" { count = local.enabled ? 1 : 0 }


### PR DESCRIPTION
## what
* ignore `last_modified` attribute of the `aws_lambda_function` resource

## why
In the past I've used this module with a local `filename` without issue, but we just used it with a new lambda function whose code we are storing externally in S3 so using the `s3_key`/`s3_bucket` attributes, and on every terraform apply it wants to update the `last_modified` attribute e.g.:

```
Terraform will perform the following actions:

  # module.xxx.aws_lambda_function.this[0] will be updated in-place
  ~ resource "aws_lambda_function" "this" {
        id                             = "xxx"
      ~ last_modified                  = "2022-07-05T22:43:11.813+0000" -> (known after apply)
        tags                           = {}
        # (20 unchanged attributes hidden)


        # (2 unchanged blocks hidden)
    }
```

Adding this lifecycle rule avoids this spurious update. I'm open to other suggestions though!
