### PR TITLE
Fix link to examples in readme

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ module "lambda" {
 
 ## Examples
 
-- [`examples/complete`](https://github.com/cloudposse/terraform-aws-lambda-function/examples/complete) - complete example of using this module
-- [`examples/docker-image`](https://github.com/cloudposse/terraform-aws-lambda-function/examples/docker-image) - example of using Lambda with Docker images
+- [`examples/complete`](https://github.com/cloudposse/terraform-aws-lambda-function/blob/main/examples/complete) - complete example of using this module
+- [`examples/docker-image`](https://github.com/cloudposse/terraform-aws-lambda-function/blob/main/examples/docker-image) - example of using Lambda with Docker images
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -75,8 +75,8 @@ usage: |-
   ```
 
 examples: |-
-  - [`examples/complete`](https://github.com/cloudposse/terraform-aws-lambda-function/examples/complete) - complete example of using this module
-  - [`examples/docker-image`](https://github.com/cloudposse/terraform-aws-lambda-function/examples/docker-image) - example of using Lambda with Docker images
+  - [`examples/complete`](https://github.com/cloudposse/terraform-aws-lambda-function/blob/main/examples/complete) - complete example of using this module
+  - [`examples/docker-image`](https://github.com/cloudposse/terraform-aws-lambda-function/blob/main/examples/docker-image) - example of using Lambda with Docker images
 
 # Other files to include in this README from the project folder
 include:


### PR DESCRIPTION
## what
* Links to examples link to a non-existing page

