### PR TITLE
add image_uri to ignore_changes if ignore_external_function_updates is true

### DIFF
--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-lambda-function&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-lambda-function&utm_content=website
@@ -447,3 +447,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-lambda-function
   [share_email]: mailto:?subject=terraform-aws-lambda-function&body=https://github.com/cloudposse/terraform-aws-lambda-function
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-lambda-function?pixel&cs=github&cm=readme&an=terraform-aws-lambda-function
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -82,8 +82,9 @@ resource "aws_lambda_function" "this" {
   depends_on = [module.cloudwatch_log_group]
 
   lifecycle {
-    ignore_changes = [last_modified]
+    ignore_changes = var.ignore_external_function_updates ? [last_modified, image_uri] : [last_modified]
   }
+
 }
 
 data "aws_partition" "this" {

--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ resource "aws_lambda_function" "this" {
   depends_on = [module.cloudwatch_log_group]
 
   lifecycle {
-    ignore_changes = var.ignore_external_function_updates ? [last_modified, image_uri] : [last_modified]
+    ignore_changes = [last_modified, image_uri]
   }
 
 }


### PR DESCRIPTION


## what
* Looks like ignore_external_function_updates property although exposed as an input variable isnt implemented.

## why
* Input variable input_ignore_external_function_updates doesnt do what it's expected to do
* This commit adds image_uri to the list of properties to ignore while detecting changes for tf plan/apply.

## references
* https://github.com/cloudposse/terraform-aws-lambda-function#input_ignore_external_function_updates 
* Existing bug ticket - https://github.com/cloudposse/terraform-aws-lambda-function/issues/26

