### PR TITLE
feat: add CloudWatch event rules and add missed CloudWatch log outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,15 @@ Available targets:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_cloudwatch_log_group"></a> [cloudwatch\_log\_group](#module\_cloudwatch\_log\_group) | cloudposse/cloudwatch-logs/aws | 0.6.6 |
+| <a name="module_event_rule_label"></a> [event\_rule\_label](#module\_event\_rule\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
+| [aws_cloudwatch_event_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_iam_policy.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.cloudwatch_insights](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -167,6 +170,8 @@ Available targets:
 | [aws_iam_role_policy_attachment.vpc_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.xray](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_function.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_function_event_invoke_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) | resource |
+| [aws_lambda_permission.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -180,7 +185,7 @@ Available targets:
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_architectures"></a> [architectures](#input\_architectures) | Instruction set architecture for your Lambda function. Valid values are ["x86\_64"] and ["arm64"].<br>    Default is ["x86\_64"]. Removing this attribute, function's architecture stay the same. | `list(string)` | `null` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
-| <a name="input_cloudwatch_event_rules"></a> [cloudwatch\_event\_rules](#input\_cloudwatch\_event\_rules) | Creates EventBridge (CloudWatch Events) rules for invoking the Lambda Function along with the required permissions. | `map(any)` | `{}` | no |
+| <a name="input_cloudwatch_event_rules"></a> [cloudwatch\_event\_rules](#input\_cloudwatch\_event\_rules) | A list of CloudWatch Events rules for invoking the Lambda Function along with the required permissions.<br>  name:<br>    The name of the rule.<br>  schedule\_expression:<br>    The scheduling expression. For example, `cron(0 20 * * ? *)` or `rate(5 minutes)`.<br>    At least one of `schedule_expression` or `event_pattern` is required.<br>  event\_pattern:<br>    The event pattern described a JSON object.<br>  description:<br>    The description of the rule. | `list(any)` | `[]` | no |
 | <a name="input_cloudwatch_lambda_insights_enabled"></a> [cloudwatch\_lambda\_insights\_enabled](#input\_cloudwatch\_lambda\_insights\_enabled) | Enable CloudWatch Lambda Insights for the Lambda Function. | `bool` | `false` | no |
 | <a name="input_cloudwatch_log_subscription_filters"></a> [cloudwatch\_log\_subscription\_filters](#input\_cloudwatch\_log\_subscription\_filters) | CloudWatch Logs subscription filter resources. Currently supports only Lambda functions as destinations. | `map(any)` | `{}` | no |
 | <a name="input_cloudwatch_logs_kms_key_arn"></a> [cloudwatch\_logs\_kms\_key\_arn](#input\_cloudwatch\_logs\_kms\_key\_arn) | The ARN of the KMS Key to use when encrypting log data. | `string` | `null` | no |
@@ -193,6 +198,7 @@ Available targets:
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_event_invoke_config"></a> [event\_invoke\_config](#input\_event\_invoke\_config) | Manages an asynchronous invocation configuration for a Lambda Function.<br>  maximum\_event\_age\_in\_seconds:<br>     Maximum age of a request that Lambda sends to a function for processing in seconds. Valid values between 60 and 21600.<br>  maximum\_retry\_attempts :<br>    Maximum number of times to retry when the function returns an error. Valid values between 0 and 2. | <pre>object(<br>    {<br>      maximum_event_age_in_seconds = number<br>      maximum_retry_attempts       = number<br>    }<br>  )</pre> | <pre>{<br>  "maximum_event_age_in_seconds": 360,<br>  "maximum_retry_attempts": 0<br>}</pre> | no |
 | <a name="input_event_source_mappings"></a> [event\_source\_mappings](#input\_event\_source\_mappings) | Creates event source mappings to allow the Lambda function to get events from Kinesis, DynamoDB and SQS. The IAM role<br>  of this Lambda function will be enhanced with necessary minimum permissions to get those events. | `any` | `{}` | no |
 | <a name="input_filename"></a> [filename](#input\_filename) | The path to the function's deployment package within the local filesystem. If defined, The s3\_-prefixed options and image\_uri cannot be used. | `string` | `null` | no |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | Unique name for the Lambda Function. | `string` | n/a | yes |
@@ -222,7 +228,6 @@ Available targets:
 | <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | The S3 bucket location containing the function's deployment package. Conflicts with filename and image\_uri.<br>  This bucket must reside in the same AWS region where you are creating the Lambda function. | `string` | `null` | no |
 | <a name="input_s3_key"></a> [s3\_key](#input\_s3\_key) | The S3 key of an object containing the function's deployment package. Conflicts with filename and image\_uri. | `string` | `null` | no |
 | <a name="input_s3_object_version"></a> [s3\_object\_version](#input\_s3\_object\_version) | The object version containing the function's deployment package. Conflicts with filename and image\_uri. | `string` | `null` | no |
-| <a name="input_sns_subscriptions"></a> [sns\_subscriptions](#input\_sns\_subscriptions) | Creates subscriptions to SNS topics which trigger the Lambda Function. Required Lambda invocation permissions will be generated. | `map(any)` | `{}` | no |
 | <a name="input_source_code_hash"></a> [source\_code\_hash](#input\_source\_code\_hash) | Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the package file specified with either<br>  filename or s3\_key. The usual way to set this is filebase64sha256('file.zip') where 'file.zip' is the local filename<br>  of the lambda function source archive. | `string` | `""` | no |
 | <a name="input_ssm_parameter_names"></a> [ssm\_parameter\_names](#input\_ssm\_parameter\_names) | List of AWS Systems Manager Parameter Store parameter names. The IAM role of this Lambda function will be enhanced<br>  with read permissions for those parameters. Parameters must start with a forward slash and can be encrypted with the<br>  default KMS key. | `list(string)` | `null` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
@@ -237,6 +242,11 @@ Available targets:
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN of the lambda function |
+| <a name="output_cloudwatch_event_rule_arns"></a> [cloudwatch\_event\_rule\_arns](#output\_cloudwatch\_event\_rule\_arns) | A list of CloudWatch event rule ARNs |
+| <a name="output_cloudwatch_event_rule_ids"></a> [cloudwatch\_event\_rule\_ids](#output\_cloudwatch\_event\_rule\_ids) | A list of CloudWatch event rule IDs |
+| <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | ARN of the log group |
+| <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | Name of log group |
+| <a name="output_cloudwatch_stream_arns"></a> [cloudwatch\_stream\_arns](#output\_cloudwatch\_stream\_arns) | ARNs of the log streams |
 | <a name="output_function_name"></a> [function\_name](#output\_function\_name) | Lambda function name |
 | <a name="output_invoke_arn"></a> [invoke\_arn](#output\_invoke\_arn) | Invoke ARN of the lambda function |
 | <a name="output_qualified_arn"></a> [qualified\_arn](#output\_qualified\_arn) | ARN identifying your Lambda Function Version (if versioning is enabled via publish = true) |
@@ -416,7 +426,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-lambda-function&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-lambda-function&utm_content=website
@@ -447,3 +457,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-lambda-function
   [share_email]: mailto:?subject=terraform-aws-lambda-function&body=https://github.com/cloudposse/terraform-aws-lambda-function
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-lambda-function?pixel&cs=github&cm=readme&an=terraform-aws-lambda-function
+<!-- markdownlint-restore -->

--- a/cloudwatch_event_rules.tf
+++ b/cloudwatch_event_rules.tf
@@ -1,0 +1,41 @@
+locals {
+  cloudwatch_event_rules = local.enabled ? { for rule in var.cloudwatch_event_rules : rule.name => rule } : {}
+}
+
+module "event_rule_label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  for_each = local.cloudwatch_event_rules
+
+  attributes = [each.key]
+  context    = module.this.context
+}
+
+resource "aws_cloudwatch_event_rule" "this" {
+  for_each = local.cloudwatch_event_rules
+
+  name                = module.event_rule_label[each.key].id
+  schedule_expression = lookup(each.value, "schedule_expression", null)
+  event_pattern       = lookup(each.value, "event_pattern", null)
+  description         = lookup(each.value, "description", null) == null ? "Managed by Terraform" : each.value.description
+  tags                = module.event_rule_label[each.key].tags
+}
+
+resource "aws_cloudwatch_event_target" "this" {
+  for_each = local.cloudwatch_event_rules
+
+  target_id = module.event_rule_label[each.key].id
+  rule      = aws_cloudwatch_event_rule.this[each.key].name
+  arn       = join("", aws_lambda_function.this[*].arn)
+}
+
+resource "aws_lambda_permission" "this" {
+  for_each = local.cloudwatch_event_rules
+
+  statement_id  = module.event_rule_label[each.key].id
+  action        = "lambda:InvokeFunction"
+  principal     = "events.amazonaws.com"
+  function_name = join("", aws_lambda_function.this[*].function_name)
+  source_arn    = aws_cloudwatch_event_rule.this[each.key].arn
+}

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -17,12 +17,15 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_cloudwatch_log_group"></a> [cloudwatch\_log\_group](#module\_cloudwatch\_log\_group) | cloudposse/cloudwatch-logs/aws | 0.6.6 |
+| <a name="module_event_rule_label"></a> [event\_rule\_label](#module\_event\_rule\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
+| [aws_cloudwatch_event_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_iam_policy.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.cloudwatch_insights](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -32,6 +35,8 @@
 | [aws_iam_role_policy_attachment.vpc_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.xray](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_function.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_function_event_invoke_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) | resource |
+| [aws_lambda_permission.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -45,7 +50,7 @@
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_architectures"></a> [architectures](#input\_architectures) | Instruction set architecture for your Lambda function. Valid values are ["x86\_64"] and ["arm64"].<br>    Default is ["x86\_64"]. Removing this attribute, function's architecture stay the same. | `list(string)` | `null` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
-| <a name="input_cloudwatch_event_rules"></a> [cloudwatch\_event\_rules](#input\_cloudwatch\_event\_rules) | Creates EventBridge (CloudWatch Events) rules for invoking the Lambda Function along with the required permissions. | `map(any)` | `{}` | no |
+| <a name="input_cloudwatch_event_rules"></a> [cloudwatch\_event\_rules](#input\_cloudwatch\_event\_rules) | A list of CloudWatch Events rules for invoking the Lambda Function along with the required permissions.<br>  name:<br>    The name of the rule.<br>  schedule\_expression:<br>    The scheduling expression. For example, `cron(0 20 * * ? *)` or `rate(5 minutes)`.<br>    At least one of `schedule_expression` or `event_pattern` is required.<br>  event\_pattern:<br>    The event pattern described a JSON object.<br>  description:<br>    The description of the rule. | `list(any)` | `[]` | no |
 | <a name="input_cloudwatch_lambda_insights_enabled"></a> [cloudwatch\_lambda\_insights\_enabled](#input\_cloudwatch\_lambda\_insights\_enabled) | Enable CloudWatch Lambda Insights for the Lambda Function. | `bool` | `false` | no |
 | <a name="input_cloudwatch_log_subscription_filters"></a> [cloudwatch\_log\_subscription\_filters](#input\_cloudwatch\_log\_subscription\_filters) | CloudWatch Logs subscription filter resources. Currently supports only Lambda functions as destinations. | `map(any)` | `{}` | no |
 | <a name="input_cloudwatch_logs_kms_key_arn"></a> [cloudwatch\_logs\_kms\_key\_arn](#input\_cloudwatch\_logs\_kms\_key\_arn) | The ARN of the KMS Key to use when encrypting log data. | `string` | `null` | no |
@@ -58,6 +63,7 @@
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_event_invoke_config"></a> [event\_invoke\_config](#input\_event\_invoke\_config) | Manages an asynchronous invocation configuration for a Lambda Function.<br>  maximum\_event\_age\_in\_seconds:<br>     Maximum age of a request that Lambda sends to a function for processing in seconds. Valid values between 60 and 21600.<br>  maximum\_retry\_attempts :<br>    Maximum number of times to retry when the function returns an error. Valid values between 0 and 2. | <pre>object(<br>    {<br>      maximum_event_age_in_seconds = number<br>      maximum_retry_attempts       = number<br>    }<br>  )</pre> | <pre>{<br>  "maximum_event_age_in_seconds": 360,<br>  "maximum_retry_attempts": 0<br>}</pre> | no |
 | <a name="input_event_source_mappings"></a> [event\_source\_mappings](#input\_event\_source\_mappings) | Creates event source mappings to allow the Lambda function to get events from Kinesis, DynamoDB and SQS. The IAM role<br>  of this Lambda function will be enhanced with necessary minimum permissions to get those events. | `any` | `{}` | no |
 | <a name="input_filename"></a> [filename](#input\_filename) | The path to the function's deployment package within the local filesystem. If defined, The s3\_-prefixed options and image\_uri cannot be used. | `string` | `null` | no |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | Unique name for the Lambda Function. | `string` | n/a | yes |
@@ -87,7 +93,6 @@
 | <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | The S3 bucket location containing the function's deployment package. Conflicts with filename and image\_uri.<br>  This bucket must reside in the same AWS region where you are creating the Lambda function. | `string` | `null` | no |
 | <a name="input_s3_key"></a> [s3\_key](#input\_s3\_key) | The S3 key of an object containing the function's deployment package. Conflicts with filename and image\_uri. | `string` | `null` | no |
 | <a name="input_s3_object_version"></a> [s3\_object\_version](#input\_s3\_object\_version) | The object version containing the function's deployment package. Conflicts with filename and image\_uri. | `string` | `null` | no |
-| <a name="input_sns_subscriptions"></a> [sns\_subscriptions](#input\_sns\_subscriptions) | Creates subscriptions to SNS topics which trigger the Lambda Function. Required Lambda invocation permissions will be generated. | `map(any)` | `{}` | no |
 | <a name="input_source_code_hash"></a> [source\_code\_hash](#input\_source\_code\_hash) | Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the package file specified with either<br>  filename or s3\_key. The usual way to set this is filebase64sha256('file.zip') where 'file.zip' is the local filename<br>  of the lambda function source archive. | `string` | `""` | no |
 | <a name="input_ssm_parameter_names"></a> [ssm\_parameter\_names](#input\_ssm\_parameter\_names) | List of AWS Systems Manager Parameter Store parameter names. The IAM role of this Lambda function will be enhanced<br>  with read permissions for those parameters. Parameters must start with a forward slash and can be encrypted with the<br>  default KMS key. | `list(string)` | `null` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
@@ -102,6 +107,11 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN of the lambda function |
+| <a name="output_cloudwatch_event_rule_arns"></a> [cloudwatch\_event\_rule\_arns](#output\_cloudwatch\_event\_rule\_arns) | A list of CloudWatch event rule ARNs |
+| <a name="output_cloudwatch_event_rule_ids"></a> [cloudwatch\_event\_rule\_ids](#output\_cloudwatch\_event\_rule\_ids) | A list of CloudWatch event rule IDs |
+| <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | ARN of the log group |
+| <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | Name of log group |
+| <a name="output_cloudwatch_stream_arns"></a> [cloudwatch\_stream\_arns](#output\_cloudwatch\_stream\_arns) | ARNs of the log streams |
 | <a name="output_function_name"></a> [function\_name](#output\_function\_name) | Lambda function name |
 | <a name="output_invoke_arn"></a> [invoke\_arn](#output\_invoke\_arn) | Invoke ARN of the lambda function |
 | <a name="output_qualified_arn"></a> [qualified\_arn](#output\_qualified\_arn) | ARN identifying your Lambda Function Version (if versioning is enabled via publish = true) |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -89,6 +89,13 @@ module "lambda" {
     # aws_iam_policy.inside[0].id, # This will result in an error message and is why we use local.policy_name_inside
   ]
 
+  cloudwatch_event_rules = [
+    {
+      name                = "minutely"
+      schedule_expression = "cron(0/1 * * * ? *)"
+    }
+  ]
+
   context = module.this.context
 
   depends_on = [aws_iam_policy.inside]

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -2,3 +2,53 @@ output "arn" {
   description = "ARN of the lambda function"
   value       = module.lambda.arn
 }
+
+output "invoke_arn" {
+  description = "Invoke ARN of the lambda function"
+  value       = module.lambda.invoke_arn
+}
+
+output "qualified_arn" {
+  description = "ARN identifying your Lambda Function Version (if versioning is enabled via publish = true)"
+  value       = module.lambda.qualified_arn
+}
+
+output "function_name" {
+  description = "Lambda function name"
+  value       = module.lambda.function_name
+}
+
+output "role_name" {
+  description = "Lambda IAM role name"
+  value       = module.lambda.role_name
+}
+
+output "role_arn" {
+  description = "Lambda IAM role ARN"
+  value       = module.lambda.role_arn
+}
+
+output "cloudwatch_log_group_arn" {
+  description = "ARN of the log group"
+  value       = module.lambda.cloudwatch_log_group_arn
+}
+
+output "cloudwatch_stream_arns" {
+  description = "ARNs of the log streams"
+  value       = module.lambda.cloudwatch_stream_arns
+}
+
+output "cloudwatch_log_group_name" {
+  description = "Name of log group"
+  value       = module.lambda.cloudwatch_log_group_name
+}
+
+output "cloudwatch_event_rule_ids" {
+  description = "A list of CloudWatch event rule IDs"
+  value       = module.lambda.cloudwatch_event_rule_ids
+}
+
+output "cloudwatch_event_rule_arns" {
+  description = "A list of CloudWatch event rule ARNs"
+  value       = module.lambda.cloudwatch_event_rule_arns
+}

--- a/main.tf
+++ b/main.tf
@@ -86,6 +86,14 @@ resource "aws_lambda_function" "this" {
   }
 }
 
+resource "aws_lambda_function_event_invoke_config" "this" {
+  count = local.enabled ? 1 : 0
+
+  function_name                = join("", aws_lambda_function.this[*].function_name)
+  maximum_event_age_in_seconds = var.event_invoke_config["maximum_event_age_in_seconds"]
+  maximum_retry_attempts       = var.event_invoke_config["maximum_retry_attempts"]
+}
+
 data "aws_partition" "this" {
   count = local.enabled ? 1 : 0
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,28 @@ output "role_arn" {
   description = "Lambda IAM role ARN"
   value       = local.enabled ? aws_iam_role.this[0].arn : null
 }
+
+output "cloudwatch_log_group_arn" {
+  value       = module.cloudwatch_log_group.log_group_arn
+  description = "ARN of the log group"
+}
+
+output "cloudwatch_stream_arns" {
+  value       = module.cloudwatch_log_group.stream_arns
+  description = "ARNs of the log streams"
+}
+
+output "cloudwatch_log_group_name" {
+  description = "Name of log group"
+  value       = module.cloudwatch_log_group.log_group_name
+}
+
+output "cloudwatch_event_rule_ids" {
+  description = "A list of CloudWatch event rule IDs"
+  value       = try(values(aws_cloudwatch_event_rule.this)[*]["id"], null)
+}
+
+output "cloudwatch_event_rule_arns" {
+  description = "A list of CloudWatch event rule ARNs"
+  value       = try(values(aws_cloudwatch_event_rule.this)[*]["arn"], null)
+}

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -39,7 +39,26 @@ func TestExamplesComplete(t *testing.T) {
 
 	// Run `terraform output` to get the value of an output variable
 	arn := terraform.Output(t, terraformOptions, "arn")
-	assert.NotNil(t, arn)
+	invokeARN := terraform.Output(t, terraformOptions, "invoke_arn")
+	qualifiedARN := terraform.Output(t, terraformOptions, "qualified_arn")
+	functionName := terraform.Output(t, terraformOptions, "function_name")
+	roleName := terraform.Output(t, terraformOptions, "role_name")
+	roleARN := terraform.Output(t, terraformOptions, "role_arn")
+	cloudwatchLogGroupARN := terraform.Output(t, terraformOptions, "cloudwatch_log_group_arn")
+	cloudwatchLogGroupName := terraform.Output(t, terraformOptions, "cloudwatch_log_group_name")
+	cloudwatchEventRuleIDs := terraform.OutputList(t, terraformOptions, "cloudwatch_event_rule_ids")
+	cloudwatchEventRuleARNs := terraform.OutputList(t, terraformOptions, "cloudwatch_event_rule_arns")
+
+	assert.Contains(t, arn, "arn:aws:lambda:")
+	assert.Contains(t, invokeARN, "arn:aws:apigateway:")
+	assert.Contains(t, qualifiedARN, "arn:aws:lambda:")
+	assert.NotEmpty(t, functionName)
+	assert.NotEmpty(t, roleName)
+	assert.Contains(t, roleARN, "arn:aws:iam:")
+	assert.Contains(t, cloudwatchLogGroupARN, "arn:aws:logs:")
+	assert.NotEmpty(t, cloudwatchLogGroupName)
+	assert.NotEmpty(t, cloudwatchEventRuleIDs)
+	assert.NotEmpty(t, cloudwatchEventRuleARNs)
 
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,

--- a/variables.tf
+++ b/variables.tf
@@ -8,9 +8,20 @@ variable "architectures" {
 }
 
 variable "cloudwatch_event_rules" {
-  type        = map(any)
-  description = "Creates EventBridge (CloudWatch Events) rules for invoking the Lambda Function along with the required permissions."
-  default     = {}
+  type        = list(any)
+  description = <<-DOC
+    A list of CloudWatch Events rules for invoking the Lambda Function along with the required permissions.
+      name:
+        The name of the rule.
+      schedule_expression:
+        The scheduling expression. For example, `cron(0 20 * * ? *)` or `rate(5 minutes)`.
+        At least one of `schedule_expression` or `event_pattern` is required.
+      event_pattern:
+        The event pattern described a JSON object.
+      description:
+        The description of the rule.
+  DOC
+  default     = []
 }
 
 variable "cloudwatch_lambda_insights_enabled" {
@@ -189,12 +200,6 @@ variable "s3_object_version" {
   default     = null
 }
 
-variable "sns_subscriptions" {
-  type        = map(any)
-  description = "Creates subscriptions to SNS topics which trigger the Lambda Function. Required Lambda invocation permissions will be generated."
-  default     = {}
-}
-
 variable "source_code_hash" {
   type        = string
   description = <<EOF
@@ -259,4 +264,24 @@ variable "iam_policy_description" {
   type        = string
   description = "Description of the IAM policy for the Lambda IAM role"
   default     = "Provides minimum SSM read permissions."
+}
+
+variable "event_invoke_config" {
+  type = object(
+    {
+      maximum_event_age_in_seconds = number
+      maximum_retry_attempts       = number
+    }
+  )
+  description = <<-DOC
+    Manages an asynchronous invocation configuration for a Lambda Function.
+      maximum_event_age_in_seconds:
+         Maximum age of a request that Lambda sends to a function for processing in seconds. Valid values between 60 and 21600.
+      maximum_retry_attempts :
+        Maximum number of times to retry when the function returns an error. Valid values between 0 and 2.
+  DOC
+  default = {
+    maximum_event_age_in_seconds = 360
+    maximum_retry_attempts       = 0
+  }
 }


### PR DESCRIPTION
## what
* add CloudWatch event rules
* add missed CloudWatch log outputs
* remove variable `sns_subscriptions`

## why
* CloudWatch event rules are useful for invoking lambda by cron expressions
* CloudWatch log out puts are useful for external usage
* `sns_subscriptions` is an unused variables

## references
* `Closes #27 `
