### PR TITLE
fix: make sure attachments are ready before creating lambda function

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,15 @@ resource "aws_lambda_function" "this" {
     }
   }
 
-  depends_on = [module.cloudwatch_log_group]
+  depends_on = [
+    module.cloudwatch_log_group,
+    aws_iam_role_policy_attachment.cloudwatch_insights,
+    aws_iam_role_policy_attachment.cloudwatch_logs,
+    aws_iam_role_policy_attachment.custom,
+    aws_iam_role_policy_attachment.ssm,
+    aws_iam_role_policy_attachment.vpc_access,
+    aws_iam_role_policy_attachment.xray
+  ]
 
   lifecycle {
     ignore_changes = [last_modified]


### PR DESCRIPTION
This PR fixes the lambda creation issue, where permissions are required.

For example, if you add `vpc_config,` the lambda will fail on the first attempt since no attachment has been made to the IAM role. That's the only edge case.

Fixing by adding depends_on to attachments as they are implicitly required to exist before the lambda resource creation.

