### PR TITLE
fix: Add null/label context tags to the aws_lambda_function resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "aws_lambda_function" "this" {
   s3_key                         = var.s3_key
   s3_object_version              = var.s3_object_version
   source_code_hash               = var.source_code_hash
-  tags                           = var.tags
+  tags                           = module.this.tags
   timeout                        = var.timeout
 
   dynamic "dead_letter_config" {


### PR DESCRIPTION
## What

Use `tags = module.this.tags` on the `aws_lambda_function` resource.

## Why

Prior to this, the `aws_lambda_function` resource was not getting tagged at all
when passing just the null/label context into the module.

For example, this would end up with a completely untagged Lambda function even
though I am passing the context from a standard null/label declaration:

```
module "test" {
  source  = "cloudposse/lambda-function/aws"
  version = "0.5.1"

  function_name = "${module.this.id}-test"
  attributes    = ["foo"]
  description   = var.lambda_description
  s3_bucket     = var.lambda_s3_bucket
  s3_key        = var.lambda_s3_key
  runtime       = var.lambda_runtime
  handler       = var.lambda_handler
  context       = module.this.context
}
```

To get any tags on the lambda, the `tags` attribute must be used:

```
module "test" {
  source  = "cloudposse/lambda-function/aws"
  version = "0.5.1"

  function_name = "${module.this.id}-test"
  attributes    = ["foo"]
  description   = var.lambda_description
  s3_bucket     = var.lambda_s3_bucket
  s3_key        = var.lambda_s3_key
  runtime       = var.lambda_runtime
  handler       = var.lambda_handler
  context       = module.this.context
  tags          = module.this.tags
}
```

This has a couple of problems:
1) The `attributes` list is missing from the resultant set of tags.
2) The requirement of passing an explicit `tags` attribute is not how other CloudPosse modules work.


## Outcome

* The `aws_lambda_function` resource is tagged with the implicit tags passed in via `context`.
* Tags from the `tags` variable are still present, but are now merged with the tags from `context`.
* This module follows the convetion of other CloudPosse modules.
* People used to CloudPosse modules will have an easier time using this module.

