### PR TITLE
Add support for inline IAM policy

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -90,6 +90,19 @@ module "lambda" {
     # aws_iam_policy.inside[0].id, # This will result in an error message and is why we use local.policy_name_inside
   ]
 
+  inline_iam_policy = <<-JSON
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Deny",
+          "Action": "ec2:DescribeInstanceTypes",
+          "Resource": "*"
+        }
+      ]
+    }
+  JSON
+
   context = module.this.context
 
   depends_on = [aws_iam_policy.inside]

--- a/iam-role.tf
+++ b/iam-role.tf
@@ -91,3 +91,10 @@ resource "aws_iam_role_policy_attachment" "custom" {
   role       = aws_iam_role.this[0].name
   policy_arn = each.value
 }
+
+resource "aws_iam_role_policy" "inline" {
+  count = try((local.enabled && var.inline_iam_policy != null), false) ? 1 : 0
+
+  role   = aws_iam_role.this[0].name
+  policy = var.inline_iam_policy
+}

--- a/variables.tf
+++ b/variables.tf
@@ -233,3 +233,9 @@ variable "iam_policy_description" {
   description = "Description of the IAM policy for the Lambda IAM role"
   default     = "Provides minimum SSM read permissions."
 }
+
+variable "inline_iam_policy" {
+  type        = string
+  description = "Inline policy document (JSON) to attach to the lambda role"
+  default     = null
+}


### PR DESCRIPTION
## what

Adds support for attaching an inline IAM policy to the function IAM role.

## why

Useful for defining a (simple) IAM policy that is declared, and deployed, in-tandem with the Lambda function itself. 

Our use case: we use terragrunt to deploy a simple function using this module (straight out of terraform registry), so we'd like to avoid having to create a wrapper module or a separate customer-managed policy, for adding some necessary (but simple) permissions.

## references

No related GitHub issue (but I can create one if needed).