### PR TITLE
Bugfix: Revert Breaking Change in v0.6.0

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -7,8 +7,8 @@ locals {
 
   policy_arn_prefix = format(
     "arn:%s:iam::%s:policy",
-    join("", data.aws_partition.current.*.partition),
-    join("", data.aws_caller_identity.current.*.account_id),
+    join("", data.aws_partition.current[*].partition),
+    join("", data.aws_caller_identity.current[*].account_id),
   )
 
   policy_arn_inside = format("%s/%s", local.policy_arn_prefix, local.policy_name_inside)
@@ -77,7 +77,7 @@ resource "aws_iam_role_policy_attachment" "outside" {
 module "lambda" {
   source = "../.."
 
-  filename               = join("", data.archive_file.lambda_zip.*.output_path)
+  filename               = join("", data.archive_file.lambda_zip[*].output_path)
   function_name          = module.label.id
   handler                = var.handler
   runtime                = var.runtime

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -2,3 +2,18 @@ output "arn" {
   description = "ARN of the lambda function"
   value       = module.lambda.arn
 }
+
+output "function_name" {
+  description = "Lambda function name"
+  value = module.lambda.function_name
+}
+
+output "role_name" {
+  description = "Lambda IAM role name"
+  value = module.lambda.role_name
+}
+
+output "cloudwatch_log_group_name" {
+  description = "Name of Cloudwatch log group"
+  value = module.lambda_cloudwatch_log_group_name
+}

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -5,15 +5,15 @@ output "arn" {
 
 output "function_name" {
   description = "Lambda function name"
-  value = module.lambda.function_name
+  value       = module.lambda.function_name
 }
 
 output "role_name" {
   description = "Lambda IAM role name"
-  value = module.lambda.role_name
+  value       = module.lambda.role_name
 }
 
 output "cloudwatch_log_group_name" {
   description = "Name of Cloudwatch log group"
-  value = module.lambda.cloudwatch_log_group_name
+  value       = module.lambda.cloudwatch_log_group_name
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -15,5 +15,5 @@ output "role_name" {
 
 output "cloudwatch_log_group_name" {
   description = "Name of Cloudwatch log group"
-  value = module.lambda_cloudwatch_log_group_name
+  value = module.lambda.cloudwatch_log_group_name
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.0"
     }
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.0"
+    }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -9,11 +9,14 @@ module "cloudwatch_log_group" {
   source  = "cloudposse/cloudwatch-logs/aws"
   version = "0.6.6"
 
+  enabled = module.this.enabled
+
   iam_role_enabled  = false
   kms_key_arn       = var.cloudwatch_logs_kms_key_arn
   retention_in_days = var.cloudwatch_logs_retention_in_days
   name              = "/aws/lambda/${var.function_name}"
-  context           = module.this.context
+
+  tags           = module.this.tags
 }
 
 resource "aws_lambda_function" "this" {

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ module "cloudwatch_log_group" {
   retention_in_days = var.cloudwatch_logs_retention_in_days
   name              = "/aws/lambda/${var.function_name}"
 
-  tags           = module.this.tags
+  tags = module.this.tags
 }
 
 resource "aws_lambda_function" "this" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,8 @@ output "role_arn" {
   description = "Lambda IAM role ARN"
   value       = local.enabled ? aws_iam_role.this[0].arn : null
 }
+
+output "cloudwatch_log_group_name" {
+  description = "Name of Cloudwatch log group"
+  value       = local.enabled ? module.cloudwatch_log_group.name : null
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,5 +30,5 @@ output "role_arn" {
 
 output "cloudwatch_log_group_name" {
   description = "Name of Cloudwatch log group"
-  value       = local.enabled ? module.cloudwatch_log_group.name : null
+  value       = local.enabled ? module.cloudwatch_log_group.log_group_name : null
 }

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -39,7 +39,15 @@ func TestExamplesComplete(t *testing.T) {
 
 	// Run `terraform output` to get the value of an output variable
 	arn := terraform.Output(t, terraformOptions, "arn")
+	function_name := terraform.Output(t, terraformOptions, "function_name")
+  role_name := terraform.Output(t, terraformOptions, "role_name")
+  cloudwatch_log_group_name := terraform.Output(t, terraformOptions, "cloudwatch_log_group_name")
+
+  // Validate values returned by terraform
 	assert.NotNil(t, arn)
+  assert.Equal(t, "todo", function_name)
+  assert.Equal(t, "todo", role_name)
+  assert.Equal(t, "todo", cloudwatch_log_group_name)
 
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -43,7 +43,7 @@ func TestExamplesComplete(t *testing.T) {
 	role_name := terraform.Output(t, terraformOptions, "role_name")
 	cloudwatch_log_group_name := terraform.Output(t, terraformOptions, "cloudwatch_log_group_name")
 
-  // Validate values returned by terraform
+	// Validate values returned by terraform
 	assert.NotNil(t, arn)
 	assert.Equal(t, "eg-ue2-test-" + randID + "-example-complete", function_name)
 	assert.Equal(t, "eg-ue2-test-" + randID + "-example-complete-us-east-2", role_name)

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -45,9 +45,9 @@ func TestExamplesComplete(t *testing.T) {
 
   // Validate values returned by terraform
 	assert.NotNil(t, arn)
-	assert.Equal(t, "todo", function_name)
-	assert.Equal(t, "todo", role_name)
-	assert.Equal(t, "todo", cloudwatch_log_group_name)
+	assert.Equal(t, "eg-ue2-test-" + randID + "-example-complete", function_name)
+	assert.Equal(t, "eg-ue2-test-" + randID + "-example-complete-us-east-2", role_name)
+	assert.Equal(t, "/aws/lambda/eg-ue2-test-" + randID + "-example-complete", cloudwatch_log_group_name)
 
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -40,14 +40,14 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	arn := terraform.Output(t, terraformOptions, "arn")
 	function_name := terraform.Output(t, terraformOptions, "function_name")
-  role_name := terraform.Output(t, terraformOptions, "role_name")
-  cloudwatch_log_group_name := terraform.Output(t, terraformOptions, "cloudwatch_log_group_name")
+	role_name := terraform.Output(t, terraformOptions, "role_name")
+	cloudwatch_log_group_name := terraform.Output(t, terraformOptions, "cloudwatch_log_group_name")
 
   // Validate values returned by terraform
 	assert.NotNil(t, arn)
-  assert.Equal(t, "todo", function_name)
-  assert.Equal(t, "todo", role_name)
-  assert.Equal(t, "todo", cloudwatch_log_group_name)
+	assert.Equal(t, "todo", function_name)
+	assert.Equal(t, "todo", role_name)
+	assert.Equal(t, "todo", cloudwatch_log_group_name)
 
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,


### PR DESCRIPTION
## what
- Revert changes from #74 
- Pass only `module.this.tags` to cloudwatch module, not `module.this.context`
- Add tests and necessary output to catch this going forward

## why
- If we pass everything then the resources created in the cloudwatch module will have new names!

## references
- Resolves #78 
