### PR TITLE
add statement id to reduce churn

### DIFF
--- a/iam-role.tf
+++ b/iam-role.tf
@@ -16,6 +16,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
   count = local.enabled ? 1 : 0
 
   statement {
+    sid     = ""
     actions = ["sts:AssumeRole"]
 
     principals {
@@ -58,6 +59,7 @@ data "aws_iam_policy_document" "ssm" {
   count = try((local.enabled && var.ssm_parameter_names != null && length(var.ssm_parameter_names) > 0), false) ? 1 : 0
 
   statement {
+    sid = ""
     actions = [
       "ssm:GetParameter",
       "ssm:GetParameters",


### PR DESCRIPTION
## what

Adds a statement ID to the IAM policy statements.

## why

Statement ID is a mandatory field, though not required to create as it defaults to an empty string.
Terraform continually detects this drift and tries to correct it, to no end.

## references

#62 ?
