### PR TITLE
feat: add optional source_account to lambda permissions

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -105,8 +105,9 @@ module "lambda" {
 
   invoke_function_permissions = [
     {
-      principal  = "s3.amazonaws.com"
-      source_arn = join("", aws_s3_bucket.example[*].arn)
+      principal      = "s3.amazonaws.com"
+      source_arn     = join("", aws_s3_bucket.example[*].arn)
+      source_account = join("", data.aws_caller_identity.current[*].account_id)
     }
   ]
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 1.4"
 
   required_providers {
     aws = {

--- a/examples/docker-image/versions.tf
+++ b/examples/docker-image/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 1.4"
 
   required_providers {
     aws = {

--- a/lambda-permissions.tf
+++ b/lambda-permissions.tf
@@ -1,8 +1,9 @@
 resource "aws_lambda_permission" "invoke_function" {
   for_each = local.enabled ? { for i, permission in var.invoke_function_permissions : i => permission } : {}
 
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.this[0].function_name
-  principal     = each.value.principal
-  source_arn    = each.value.source_arn
+  action         = "lambda:InvokeFunction"
+  function_name  = aws_lambda_function.this[0].function_name
+  principal      = each.value.principal
+  source_arn     = each.value.source_arn
+  source_account = each.value.source_account
 }

--- a/variables.tf
+++ b/variables.tf
@@ -256,7 +256,7 @@ variable "invoke_function_permissions" {
   Defines which external source(s) can invoke this function (action 'lambda:InvokeFunction'). Attributes map to those of https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission. 
   - principal: The AWS service or account that will invoke the function
   - source_arn: (Optional) The ARN of the specific resource that will invoke the function
-  - source_account: (Optional) The AWS account ID that is allowed to invoke the function. Used to restrict cross-account access when needed.
+  - source_account: (Optional) The AWS account ID that is allowed to invoke the function. Used to restrict cross-account access when needed. This must be specified to satisfy the config rule [lambda-function-public-access-prohibited](https://docs.aws.amazon.com/config/latest/developerguide/lambda-function-public-access-prohibited.html).
   NOTE: to keep things simple, we only expose a subset of said attributes. If a more complex configuration is needed, declare the necessary lambda permissions outside of this module
   EOF
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -248,9 +248,16 @@ variable "inline_iam_policy" {
 
 variable "invoke_function_permissions" {
   type = list(object({
-    principal  = string
-    source_arn = string
+    principal      = string
+    source_arn     = optional(string)
+    source_account = optional(string)
   }))
-  description = "Defines which external source(s) can invoke this function (action 'lambda:InvokeFunction'). Attributes map to those of https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission. NOTE: to keep things simple, we only expose a subset of said attributes. If a more complex configuration is needed, declare the necessary lambda permissions outside of this module"
+  description = <<EOF
+  Defines which external source(s) can invoke this function (action 'lambda:InvokeFunction'). Attributes map to those of https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission. 
+  - principal: The AWS service or account that will invoke the function
+  - source_arn: (Optional) The ARN of the specific resource that will invoke the function
+  - source_account: (Optional) The AWS account ID that is allowed to invoke the function. Used to restrict cross-account access when needed.
+  NOTE: to keep things simple, we only expose a subset of said attributes. If a more complex configuration is needed, declare the necessary lambda permissions outside of this module
+  EOF
   default     = []
 }


### PR DESCRIPTION



## what

- Make both source_arn and source_account optional in invoke_function_permissions
- Add comprehensive documentation for all permission fields
- Update complete example to demonstrate source_account usage

## why

Without this, you need to add custom stuff just to comply with the config rule [lambda-function-public-access-prohibited](https://docs.aws.amazon.com/config/latest/developerguide/lambda-function-public-access-prohibited.html), that requires `source_account` to be set.

It should be easy to comply with this rule using the module natively.

