### PR TITLE
feat: add cloudwatch_logs_log_group_name variable for log group name override

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,8 @@ module "cloudwatch_log_group" {
   iam_role_enabled  = false
   kms_key_arn       = var.cloudwatch_logs_kms_key_arn
   retention_in_days = var.cloudwatch_logs_retention_in_days
-  name              = "/aws/lambda/${var.function_name}"
+  name              = coalesce(var.cloudwatch_logs_log_group_name, "/aws/lambda/${var.function_name}")
+  label_value_case  = var.cloudwatch_logs_log_group_name != null ? "none" : null
 
   tags = module.this.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,12 @@ variable "cloudwatch_logs_kms_key_arn" {
   default     = null
 }
 
+variable "cloudwatch_logs_log_group_name" {
+  type        = string
+  description = "Explicit CloudWatch log group name. If null, defaults to /aws/lambda/{function_name}."
+  default     = null
+}
+
 variable "description" {
   type        = string
   description = "Description of what the Lambda Function does."


### PR DESCRIPTION
NOTE:
`I am working in Life360, cant create PR using my Github enterprise user`

Adds a new cloudwatch_logs_log_group_name variable that allows overriding the default CloudWatch log group name (/aws/lambda/{function_name}).

  This is needed when migrating legacy Terraform configurations to Atmos, where existing Lambda functions may already have CloudWatch log groups with non-standard names. Without this override, the module would
  try to recreate the log group with the default naming convention, causing resource conflicts or unnecessary destroy/create cycles during migration.

  Changes

  - Added cloudwatch_logs_log_group_name variable (string, default null) to variables.tf
  - Updated main.tf to use coalesce() to prefer the explicit name when provided, falling back to the default /aws/lambda/${var.function_name}
  - Set label_value_case = "none" when a custom name is provided to prevent the cloudposse/cloudwatch-logs/aws module from transforming the log group name with label casing

  Usage

  module "lambda" {
    source = "cloudposse/lambda-function/aws"

    # Preserve existing log group name during Atmos migration
    cloudwatch_logs_log_group_name = "/aws/lambda/my-legacy-function"

    # ... other variables
  }

  When cloudwatch_logs_log_group_name is not set (default null), behavior is unchanged — the log group defaults to /aws/lambda/{function_name}.